### PR TITLE
Rename package from `flup` to `flup-py3`

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@
 
 from setuptools import setup, find_packages
 setup(
-    name = 'flup',
+    name = 'flup-py3',
     version = '1.0.4',
     packages = find_packages(),
     zip_safe = True,


### PR DESCRIPTION
Older version of this package on the pypi mirror was available under the
name of `flup-py3`. This breaks a few internal packages at Squirro as
these packages/tools rely on a library named `flup-py3` being there in
the virtualenv